### PR TITLE
Add host/sni extraction utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,15 @@
 # h-s_finder
+
+This repository contains a small Python utility to scan a directory for
+configuration strings containing `host` or `sni` parameters and outputs
+the extracted values.
+
+## Usage
+
+```bash
+python extract_hosts.py <directory>
+```
+
+The script will recursively search all files under the provided directory
+and print each host or SNI value it finds.
+

--- a/extract_hosts.py
+++ b/extract_hosts.py
@@ -1,0 +1,31 @@
+import os
+import re
+import sys
+
+pattern = re.compile(r"(?:host|sni)=([^\s&#]+)")
+
+def search_file(filepath):
+    try:
+        with open(filepath, 'rb') as f:
+            content = f.read().decode('utf-8', errors='ignore')
+    except Exception as e:
+        return []
+    return pattern.findall(content)
+
+def scan_directory(root_dir):
+    results = []
+    for dirpath, _, filenames in os.walk(root_dir):
+        for filename in filenames:
+            filepath = os.path.join(dirpath, filename)
+            matches = search_file(filepath)
+            results.extend(matches)
+    return results
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        print("Usage: python extract_hosts.py <directory>")
+        sys.exit(1)
+    directory = sys.argv[1]
+    hosts = scan_directory(directory)
+    for host in hosts:
+        print(host)


### PR DESCRIPTION
## Summary
- add `extract_hosts.py` to scan directories for host/SNI strings
- document usage in the README

## Testing
- `python3 -m py_compile extract_hosts.py`

------
https://chatgpt.com/codex/tasks/task_b_686cba12bcbc8321b3d822d98a3e66e8