### PR TITLE
Add UTF-8 output handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,15 @@
 # h-s_finder
+
+This repository contains a small utility script for scanning a directory and
+extracting any `host` or `sni` parameters found inside the files. The script
+prints each value it finds and also stores them in a text file using UTF-8
+encoding so that special characters are preserved across platforms.
+
+### Usage
+
+```bash
+python3 scan_hosts.py PATH_TO_SCAN -o results.txt
+```
+
+Replace `PATH_TO_SCAN` with the directory you want to search. The optional `-o`
+argument specifies the output file (defaults to `results.txt`).

--- a/scan_hosts.py
+++ b/scan_hosts.py
@@ -1,0 +1,45 @@
+import os
+import re
+import argparse
+from urllib.parse import unquote
+
+
+def extract_hosts_sni(text: str):
+    pattern = re.compile(r"(?:[?&](host|sni)=)([^&#\s]+)")
+    matches = pattern.findall(text)
+    return [unquote(val) for _, val in matches]
+
+
+def scan_directory(directory: str):
+    results = []
+    for root, _, files in os.walk(directory):
+        for name in files:
+            file_path = os.path.join(root, name)
+            try:
+                with open(file_path, 'r', errors='ignore') as f:
+                    content = f.read()
+                    results.extend(extract_hosts_sni(content))
+            except Exception:
+                # ignore non-text or unreadable files
+                continue
+    return results
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Scan directory for host or sni values")
+    parser.add_argument('path', help='Path to scan')
+    parser.add_argument('-o', '--output', default='results.txt', help='Output file')
+    args = parser.parse_args()
+
+    extracted = scan_directory(args.path)
+
+    # write output using UTF-8 to avoid UnicodeEncodeError on Windows
+    with open(args.output, 'w', encoding='utf-8') as out_file:
+        for item in extracted:
+            out_file.write(item + '\n')
+    for item in extracted:
+        print(item)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- fix UnicodeEncodeError on Windows by writing results in UTF-8
- clarify README about UTF-8 output

## Testing
- `python3 scan_hosts.py sample -o output2.txt`
- `python3 -m py_compile scan_hosts.py`


------
https://chatgpt.com/codex/tasks/task_b_686cc14b3c908321ba7c323c2ca3d5db