### PR TITLE
Add vmess link scanning

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ This repository contains a small utility script for scanning a directory and
 extracting any `host` or `sni` parameters found inside the files. The script
 prints each value it finds and also stores them in a text file using UTF-8
 encoding so that special characters are preserved across platforms.
+It also detects `vmess://` links and decodes them to extract host or sni values.
 
 ### Usage
 


### PR DESCRIPTION
## Summary
- support decoding `vmess://` links when scanning
- document vmess support in README

## Testing
- `python3 -m py_compile scan_hosts.py`

------
https://chatgpt.com/codex/tasks/task_b_686f2a425d308321b3475e0f7da54650